### PR TITLE
Fix numbering

### DIFF
--- a/input/pagecontent/v3Transition.md
+++ b/input/pagecontent/v3Transition.md
@@ -1,12 +1,12 @@
 
-# Transition from V3 to FHIR
+### Transition from V3 to FHIR
 
 In the future stakeholders can transition from V3 to FHIR.  The older specification will be supported but not extended with new features. FHIR interactions have several advantages:
 * FHIR will allow users to receive and send more information than is currently within the V3 specification.  Attributes such as Address Validation Status and comprehensive business dates on all Patient attributes will be available in FHIR, but not in V3.
 * FHIR uses JSON which makes new implementations simpler than V3
 * FHIR is being adopted throughout the health care landscape and switching to FHIR may help interoperability with other health organizations and systems
 
-## FHIR Development
+#### FHIR Development
 
 This guide is a primary source of information and describes the specification in detail.  Developers and the whole technical team should have access to this guide.
 
@@ -14,10 +14,10 @@ There are a variety of approaches one can take to develop FHIR capabilities.  FH
 
 The Client Registry team will have test Client Registry FHIR servers available to test interactions and operation validity.
 
-### Partial Implementations
+##### Partial Implementations
 As the V3 services will remain you may choose to develop some interactions with FHIR and still use other Client Registry services with V3.  This allows you to avoid a complete switch-over to FHIR all at once and instead roll out your new FHIR services as required or over a longer period.
 
-## Business Rules
+#### Business Rules
 The FHIR interface is subject to the same rules as V3.  Some examples regarding patient data:
 
 *No Browsing* - Users must be providing health services or facilitating care related to the patient prior to searching for the patient in a provincial clinical repository (e.g., PharmaNet, PLIS).

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -40,6 +40,16 @@ pages:
     title: Client Registry Overview  
   design.md:
     title: FHIR Design
+  search.md:
+    title: Search Patient
+  reviseAndMerge.md:
+    title: Add, Revise and Merge Patient
+  distributions.md:
+    title: Patient Change Notification
+  identifiers.md:
+    title: Identifiers
+  absentData.md:
+    title: Data Absent Reason
   v3Transition.md:
     title: Transition from V3 Provider to FHIR
   connectedPartner.md:
@@ -52,16 +62,7 @@ pages:
     title: Glossary
   credits.md:
     title: Credits
-  search.md:
-    title: Search Patient
-  reviseAndMerge.md:
-    title: Add, Revise and Merge Patient
-  distributions.md:
-    title: Patient Change Notification
-  identifiers.md:
-    title: Identifiers
-  absentData.md:
-    title: Data Absent Reason
+
 
 
 groups:


### PR DESCRIPTION
Changing numbering to be sequential for menu apart from Abstract page. Changed numbering on Transition page to avoid duplicate headers, made use of more sub-headings.