### PR TITLE
HCIM-430: Changing the use for PatientNotification.fsh from OUT to IN…

### DIFF
--- a/input/fsh/Operations/PatientNotification.fsh
+++ b/input/fsh/Operations/PatientNotification.fsh
@@ -15,7 +15,7 @@ Usage: #definition
 * instance = false
 * inputProfile = Canonical(SubscriptionNotificationBundle)
 * parameter[0].name = #SubscriptionNotificationBundle
-* parameter[0].use = #out
+* parameter[0].use = #in
 * parameter[0].min = 1
 * parameter[0].max = "1"
 * parameter[0].documentation = "The specific bundle entries that are needed when the Client Registry is sending a distribution (notification)."


### PR DESCRIPTION
…, to align with LRA's perspective of the notification being an inbound message to them. Traditionally, this would be labeled as an outbound since the PCR system is sending it, but this is being treated as an exception to align with client expectations and ease of understanding (this is also seems to be what the PatientNotification.fsh page was originally set to).