### PR TITLE
HCIM-445: Minor fix to change Patient from 0..1 to 1..1

### DIFF
--- a/input/fsh/OperationsBundles.fsh
+++ b/input/fsh/OperationsBundles.fsh
@@ -280,7 +280,7 @@ Description:  "A Bundle that is used in the Client Registry when sending subscri
 * entry ^slicing.discriminator.path = "resource"
 * entry ^slicing.rules = #open
 * entry ^slicing.description = "The specific bundle entries that are needed when the Client Registry is sending a subscription notification."
-* entry contains patient 0..1 MS and parameters 1..1 MS
+* entry contains patient 1..1 MS and parameters 1..1 MS
 * entry[parameters].resource only MetadataParametersSubscription
 * entry[parameters] ^short = "Subscription Metadata parameters"
 * entry[patient].resource only ClientRegistryPatient


### PR DESCRIPTION
This is a change that was identified in the initial round of requested changes, but was left out due to the ongoing discussions around OperationOutcome and separating that out into a separate bundle; after demonstrating the IG fixes/changes, we reidentified the need to change Patient into a mandatory field for distributions, so it will be added to the other pending changes in the release branch before merging those into production.